### PR TITLE
Fix #1 (Wrong ES Version In Readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yarn add mellat-checkout
 Import the package:
 ```
 const MellatCheckout = require('mellat-checkout');
-// or (ES5):
+// or (ES6):
 import MellatCheckout from 'mellat-checkout';
 ```
 Then create an instance:


### PR DESCRIPTION
Import and Export in JavaScript came from ES6 (ES2015)